### PR TITLE
Docker file updates

### DIFF
--- a/Blazemoji/Blazemoji.csproj
+++ b/Blazemoji/Blazemoji.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.4.0" />
     <PackageReference Include="BlazorMonaco" Version="3.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="[1.19.6-Preview.1, 1.19.6]" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="MudBlazor" Version="6.11.1" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
   </ItemGroup>

--- a/Blazemoji/Dockerfile
+++ b/Blazemoji/Dockerfile
@@ -3,6 +3,8 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 USER app
 WORKDIR /app
+EXPOSE 80
+EXPOSE 443
 EXPOSE 8080
 EXPOSE 8081
 

--- a/Blazemoji/Program.cs
+++ b/Blazemoji/Program.cs
@@ -8,8 +8,6 @@ using System;
 
 var builder = WebApplication.CreateBuilder(args);
 
-//builder.AddServiceDefaults();
-
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddRazorComponents()

--- a/Blazemoji/Properties/launchSettings.json
+++ b/Blazemoji/Properties/launchSettings.json
@@ -60,12 +60,13 @@
     "Docker": {
       "commandName": "Docker",
       "launchBrowser": true,
-      "launchUrl": "{Scheme}://0.0.0.0:80",
+      "launchUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "useSSL": false,
-      "publishAllPorts": true
+      "useSSL": true,
+      "publishAllPorts": true,
+      "httpPort": 5000
     }
   }
 }

--- a/Blazemoji/Services/Compiler/CompilerService.cs
+++ b/Blazemoji/Services/Compiler/CompilerService.cs
@@ -100,7 +100,6 @@ namespace Blazemoji.Services.Compiler
 
                 if (!emojicode.WaitForExit(_timeoutThreshhold))
                 {
-
                     emojicode.Kill();
                     stdOutput = emojicode.StandardOutput.ReadToEnd();
                     codeResult.Error = true;


### PR DESCRIPTION
- Expose correct ports for launch setting
- Blazemoji should now be as easy to launch as running the docker image and going to http://localhost:5000
- Code cleanup